### PR TITLE
Set the url attribute of the Response

### DIFF
--- a/requests_file.py
+++ b/requests_file.py
@@ -29,6 +29,7 @@ class FileAdapter(BaseAdapter):
             raise ValueError("file: URLs with hostname components are not permitted")
 
         resp = Response()
+        resp.url = request.url
 
         # Open the file, translate certain errors into HTTP responses
         # Use urllib's unquote to translate percent escapes into whatever

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -162,3 +162,11 @@ class FileRequestTestCase(unittest.TestCase):
         self.assertEqual(response.headers['Content-Length'], len(testdata))
         self.assertEqual(response.content, testdata)
         response.close()
+
+    def test_url_is_set(self):
+        # Open a request for this file
+        uri = "file://%s" % self._pathToURL(os.path.abspath(__file__))
+        response = self._session.get(uri)
+        self.assertEqual(uri, response.url)
+        response.close()
+


### PR DESCRIPTION
Updates the response so that it contains the `url` that was requested.