### PR TITLE
handle missing locale in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -75,6 +75,8 @@ class FileRequestTestCase(unittest.TestCase):
             self.assertEqual(response.status_code, requests.codes.not_found)
             self.assertTrue(response.text)
             response.close()
+        except locale.Error:
+            unittest.SkipTest('ru_RU.UTF-8 locale not available')
         finally:
             locale.setlocale(locale.LC_MESSAGES, saved_locale)
 


### PR DESCRIPTION
i do not know if it is fair to assume the ru_RU.UTF-8 locale will be
available for tests.

if it is missing, just skip the test