### PR TITLE
Add set_content_length flag to disable on demand setting Content-Length

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+1.4.4 (23 Apr 2020)
+==================
+- Add set_content_length flag to disable on demand setting Content-Length
+
 1.4.3 (2 Jan 2018)
 ==================
 - Skip the permissions test when running as root

--- a/requests_file.py
+++ b/requests_file.py
@@ -10,6 +10,10 @@ import io
 from six import BytesIO
 
 class FileAdapter(BaseAdapter):
+    def __init__(self, set_content_length=True):
+        super().__init__()
+        self._set_content_length = set_content_length
+
     def send(self, request, **kwargs):
         """ Wraps a file, described in request, in a Response object.
 
@@ -91,7 +95,8 @@ class FileAdapter(BaseAdapter):
             # representation of the exception into a byte stream
             resp_str = str(e).encode(locale.getpreferredencoding(False))
             resp.raw = BytesIO(resp_str)
-            resp.headers['Content-Length'] = len(resp_str)
+            if self._set_content_length:
+                resp.headers['Content-Length'] = len(resp_str)
 
             # Add release_conn to the BytesIO object
             resp.raw.release_conn = resp.raw.close
@@ -101,7 +106,7 @@ class FileAdapter(BaseAdapter):
 
             # If it's a regular file, set the Content-Length
             resp_stat = os.fstat(resp.raw.fileno())
-            if stat.S_ISREG(resp_stat.st_mode):
+            if stat.S_ISREG(resp_stat.st_mode) and self._set_content_length:
                 resp.headers['Content-Length'] = resp_stat.st_size
 
         return resp

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = [line.strip() for line in open("requirements.txt").readlines()]
 
 setup(
     name='requests-file',
-    version='1.4.3',
+    version='1.4.4',
     description='File transport adapter for Requests',
     author='David Shea',
     author_email='dshea@redhat.com',


### PR DESCRIPTION
In order to mock servers that do not set Content-Length in responses' headers.