### PR TITLE
Remove installation dependency on six

### DIFF
--- a/requests_file.py
+++ b/requests_file.py
@@ -6,8 +6,10 @@ import os
 import stat
 import locale
 import io
-
-from six import BytesIO
+try:
+    from io import BytesIO
+except ImportError:
+    from StringIO import StringIO as BytesIO
 
 
 class FileAdapter(BaseAdapter):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=1.0.0
-six


### PR DESCRIPTION
  The python2 life cycle is over and we can give up support for python2. Therefore, we no longer need to rely on the six module.